### PR TITLE
highlight output files

### DIFF
--- a/hop/scripts/prepare_files_for_robot.py
+++ b/hop/scripts/prepare_files_for_robot.py
@@ -75,7 +75,7 @@ def correct_parking_positions_file(
     df = file_functions.write_standard_parking_positions_file(df, output_file)
 
     if verbose:
-        print(f"\tOutput file: {output_file}")
+        print(f"\t********** Output file: {output_file} **********")
 
     return df, output_file
 
@@ -157,7 +157,7 @@ def correct_robot_file(
     df, output_file = file_functions.write_standard_robot_file(df, filename, header)
 
     if verbose:
-        print(f"\tOutput file: {output_file}")
+        print(f"\t********** Output file: {output_file} **********")
 
     return df
 


### PR DESCRIPTION
Modify print statements to highlight the output files.   Helps users identify the newly created files and where to find them for input into the labview fields.

I would have preferred to make them coloured but that is turning out to be surprisingly hard to do for python output in powershell.